### PR TITLE
Bug fixes for BEPS NDF translator

### DIFF
--- a/BGlib/be/translators/df_utils/be_utils.py
+++ b/BGlib/be/translators/df_utils/be_utils.py
@@ -1110,7 +1110,7 @@ def createSpecVals(udvs_mat, spec_inds, bin_freqs, bin_wfm_type, parm_dict,
                 print('\t' * 3 + 'Generated spec vals. Calling __BEPSgen')
 
             return __BEPSgen(udvs_mat, inSpecVals, bin_freqs, bin_wfm_type,
-                             parm_dict, udvs_labs, iSpecVals, udvs_units)
+                             udvs_labs, iSpecVals, udvs_units)
 
     def __BEPSDC(udvs_mat, inSpecVals, bin_freqs, bin_wfm_type, parm_dict,
                  verbose=False):


### PR DESCRIPTION
* Using ``verbose`` instead of ``debug`` as kwarg for print statements.
* Fixed bug that was preventing translation of user defined voltage spectroscopy